### PR TITLE
Fix a build problem(Apple LLVM version 6.0 / clang-600.0.56).

### DIFF
--- a/InputSourceSelector.m
+++ b/InputSourceSelector.m
@@ -10,9 +10,9 @@ int main(int argc, char const * const * argv) {
                      || strcmp(argv[1],"list-enabled") == 0)) {
         Boolean listAll = strcmp(argv[1],"list") == 0;
         NSArray *inputSources = [(NSArray *)TISCreateInputSourceList(NULL,listAll) autorelease];
-        for (TISInputSourceRef __attribute__((NSObject)) inputSource in inputSources) {
-            NSString *inputSourceID = TISGetInputSourceProperty(inputSource, kTISPropertyInputSourceID);
-            NSString *localizedName = TISGetInputSourceProperty(inputSource, kTISPropertyLocalizedName);
+        for (NSObject *inputSource in inputSources) {
+            NSString *inputSourceID = TISGetInputSourceProperty((TISInputSourceRef)inputSource, kTISPropertyInputSourceID);
+            NSString *localizedName = TISGetInputSourceProperty((TISInputSourceRef)inputSource, kTISPropertyLocalizedName);
             printf("%s (%s)\n",[inputSourceID UTF8String],[localizedName UTF8String]);
         }
     } else if (argc > 1 && (strcmp(argv[1],"current") == 0


### PR DESCRIPTION
```
$ make
gcc -o InputSourceSelector -Wall InputSourceSelector.m -framework Carbon -framework Foundation
InputSourceSelector.m:13:58: warning: 'NSObject' attribute may be put on a typedef only; attribute
      is ignored [-WNSObject-attribute]
        for (TISInputSourceRef __attribute__((NSObject)) inputSource in inputSources) {
                                                         ^
InputSourceSelector.m:13:9: error: selector element type 'TISInputSourceRef' (aka
      'struct __TISInputSource *') is not a valid object
        for (TISInputSourceRef __attribute__((NSObject)) inputSource in inputSources) {
        ^    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning and 1 error generated.
make: *** [InputSourceSelector] Error 1
```
